### PR TITLE
Enable managed container Arquillian mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,6 @@
                   <deployer/>
                   <configuration>
                      <properties>
-                        <cargo.jboss.configuration>standalone-full</cargo.jboss.configuration>
                         <cargo.wildfly.script.cli.embedded.adapter-install>${wildfly.dir}/bin/adapter-install.cli</cargo.wildfly.script.cli.embedded.adapter-install>
                      </properties>
                      <users>

--- a/travis.sh
+++ b/travis.sh
@@ -42,7 +42,7 @@ export PING_LOOP_PID=$!
 # your_build_command_2
 export LUMEER_HOME=$(pwd)/war
 export LUMEER_DEFAULTS=defaults-ci.properties
-mvn -P-default install
+mvn -Ptests install
 #mvn -P-default install -Dlumeer.db.host=ds119508.mlab.com -Dlumeer.db.port=19508 -Dlumeer.db.name=lumeer-ci
 #mvn -l $BUILD_OUTPUT -P-default install -Dlumeer.db.host=ds119508.mlab.com -Dlumeer.db.port=19508 -Dlumeer.db.name=lumeer-ci
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -179,11 +179,6 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.wildfly.arquillian</groupId>
-         <artifactId>wildfly-arquillian-container-remote</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
          <groupId>org.wildfly</groupId>
          <artifactId>wildfly-dist</artifactId>
          <type>zip</type>
@@ -427,6 +422,12 @@
             </plugin>
          </plugins>
       </pluginManagement>
+      <testResources>
+         <testResource>
+            <directory>src/test/resources</directory>
+            <filtering>true</filtering>
+         </testResource>
+      </testResources>
    </build>
 
    <profiles>
@@ -457,6 +458,23 @@
                </plugin>
             </plugins>
          </build>
+         <dependencies>
+            <dependency>
+               <groupId>org.wildfly.arquillian</groupId>
+               <artifactId>wildfly-arquillian-container-managed</artifactId>
+               <scope>test</scope>
+            </dependency>
+         </dependencies>
+      </profile>
+      <profile>
+         <id>tests</id>
+         <dependencies>
+            <dependency>
+               <groupId>org.wildfly.arquillian</groupId>
+               <artifactId>wildfly-arquillian-container-remote</artifactId>
+               <scope>test</scope>
+            </dependency>
+         </dependencies>
       </profile>
       <profile>
          <id>production</id>
@@ -476,6 +494,13 @@
                </plugin>
             </plugins>
          </build>
+         <dependencies>
+            <dependency>
+               <groupId>org.wildfly.arquillian</groupId>
+               <artifactId>wildfly-arquillian-container-remote</artifactId>
+               <scope>test</scope>
+            </dependency>
+         </dependencies>
       </profile>
       <profile>
          <id>sign</id>

--- a/war/src/test/resources/arquillian.xml
+++ b/war/src/test/resources/arquillian.xml
@@ -6,12 +6,18 @@
       <property name="deploymentExportPath">target/deployments</property>
    </engine>
 
-   <container qualifier="wildfly-remote">
+   <container qualifier="wildfly-remote" default="true">
       <configuration>
          <property name="managementAddress">127.0.0.1</property>
          <property name="managementPort">9990</property>
          <property name="username">admin</property>
          <property name="password">admin1234;</property>
+      </configuration>
+   </container>
+
+   <container qualifier="wildfly-managed">
+      <configuration>
+         <property name="jbossHome">${project.build.directory}/wildfly-10.1.0.Final</property>
       </configuration>
    </container>
 </arquillian>


### PR DESCRIPTION
This allows you to run the tests easily in your IDE without a need to
start a container manually.