### PR TITLE
Fix failing Travis build #LMR-101

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
                <artifactId>maven-surefire-plugin</artifactId>
                <version>${maven.surefire.plugin.version}</version>
                <configuration>
+                  <argLine>-Xmx256m -Xms256m</argLine>
                   <excludes>
                      <exclude>*IntegrationTest.java</exclude>
                   </excludes>
@@ -158,6 +159,7 @@
                <artifactId>maven-failsafe-plugin</artifactId>
                <version>${maven.failsafe.plugin.version}</version>
                <configuration>
+                  <argLine>-Xmx256m -Xms256m</argLine>
                   <includes>
                      <include>*IntegrationTest.java</include>
                   </includes>
@@ -185,6 +187,7 @@
                   <deployer/>
                   <configuration>
                      <properties>
+                        <cargo.jvmargs>-Xmx128m -Xms128m</cargo.jvmargs>
                         <cargo.wildfly.script.cli.embedded.adapter-install>${wildfly.dir}/bin/adapter-install.cli</cargo.wildfly.script.cli.embedded.adapter-install>
                      </properties>
                      <users>

--- a/war/src/test/resources/arquillian.xml
+++ b/war/src/test/resources/arquillian.xml
@@ -18,6 +18,7 @@
    <container qualifier="wildfly-managed">
       <configuration>
          <property name="jbossHome">${project.build.directory}/wildfly-10.1.0.Final</property>
+         <property name="javaVmArguments">-Xmx128m -Xms128m</property>
       </configuration>
    </container>
 </arquillian>


### PR DESCRIPTION
WildFly has probably used most of the memory when running the tests so this should fix our problem with Travis killing our testing jobs.

Please, do not merge it yet. I will try to run the tests multiple times to see if it really helps.