### PR TITLE
Added support for project and organization identificator

### DIFF
--- a/war/src/main/java/io/lumeer/engine/controller/CollectionMetadataFacade.java
+++ b/war/src/main/java/io/lumeer/engine/controller/CollectionMetadataFacade.java
@@ -1129,8 +1129,8 @@ public class CollectionMetadataFacade implements Serializable {
     *       project id
     * @return name of metadata collection for given project id
     */
-   public static String metadataCollection(String projectId) {
-      return LumeerConst.Collection.METADATA_COLLECTION_PREFIX + projectId;
+   public String metadataCollection(String projectId) {
+      return LumeerConst.Collection.METADATA_COLLECTION_PREFIX + projectFacade.getProjectIdentificator(projectId);
    }
 
    private Object getMetadataValue(String collection, String key) {

--- a/war/src/main/java/io/lumeer/engine/controller/OrganizationFacade.java
+++ b/war/src/main/java/io/lumeer/engine/controller/OrganizationFacade.java
@@ -55,6 +55,18 @@ public class OrganizationFacade {
    @Inject
    private DataStorageDialect dataStorageDialect;
 
+   /**
+    * Gets unique and immutable identificator of the organization - _id from DataDocument
+    *
+    * @param organizationId
+    *       organization id
+    * @return identificator
+    */
+   public String getOrganizationIdentificator(final String organizationId) {
+      DataDocument document = dataStorage.readDocumentIncludeAttrs(LumeerConst.Organization.COLLECTION_NAME, organizationIdFilter(organizationId), Collections.singletonList(LumeerConst.Document.ID));
+      return document != null ? document.getString(LumeerConst.Document.ID) : null;
+   }
+
    public String getOrganizationId() {
       return organizationId;
    }

--- a/war/src/main/java/io/lumeer/engine/controller/ProjectFacade.java
+++ b/war/src/main/java/io/lumeer/engine/controller/ProjectFacade.java
@@ -20,6 +20,7 @@
 package io.lumeer.engine.controller;
 
 import io.lumeer.engine.annotation.SystemDataStorage;
+import io.lumeer.engine.api.LumeerConst;
 import io.lumeer.engine.api.LumeerConst.Project;
 import io.lumeer.engine.api.data.DataDocument;
 import io.lumeer.engine.api.data.DataFilter;
@@ -57,6 +58,18 @@ public class ProjectFacade {
    private DatabaseInitializer databaseInitializer;
 
    private String projectId = "default";
+
+   /**
+    * Gets unique and immutable identificator of the project - _id from DataDocument
+    *
+    * @param projectId
+    *       project id
+    * @return identificator
+    */
+   public String getProjectIdentificator(final String projectId) {
+      DataDocument document = dataStorage.readDocumentIncludeAttrs(Project.COLLECTION_NAME, projectIdFilter(projectId), Collections.singletonList(LumeerConst.Document.ID));
+      return document != null ? document.getString(LumeerConst.Document.ID) : null;
+   }
 
    public String getCurrentProjectId() {
       return projectId;

--- a/war/src/main/java/io/lumeer/engine/controller/ViewFacade.java
+++ b/war/src/main/java/io/lumeer/engine/controller/ViewFacade.java
@@ -61,9 +61,6 @@ public class ViewFacade implements Serializable {
    @Inject
    private ProjectFacade projectFacade;
 
-   @Inject
-   private OrganizationFacade organizationFacade;
-
    /**
     * Creates initial metadata for the view
     *
@@ -387,6 +384,6 @@ public class ViewFacade implements Serializable {
     * @return name of view metadata collection for given project id
     */
    private String metadataCollection(String projectId) {
-      return LumeerConst.View.METADATA_COLLECTION_PREFIX + projectId;
+      return LumeerConst.View.METADATA_COLLECTION_PREFIX + projectFacade.getProjectIdentificator(projectId);
    }
 }

--- a/war/src/main/java/io/lumeer/engine/rest/OrganizationService.java
+++ b/war/src/main/java/io/lumeer/engine/rest/OrganizationService.java
@@ -104,6 +104,19 @@ public class OrganizationService implements Serializable {
 
    /**
     * @param organizationId organization id
+    * @param newId new organization id
+    */
+   @PUT
+   @Path("/{organizationId}/id/{newId}")
+   public void updateOrganizationId(final @PathParam("organizationId") String organizationId, final @PathParam("newId") String newId) {
+      if (organizationId == null || newId == null) {
+         throw new IllegalArgumentException();
+      }
+      organizationFacade.updateOrganizationId(organizationId, newId);
+   }
+
+   /**
+    * @param organizationId organization id
     */
    @DELETE
    @Path("/{organizationId}")

--- a/war/src/test/java/io/lumeer/engine/rest/OrganizationServiceIntegrationTest.java
+++ b/war/src/test/java/io/lumeer/engine/rest/OrganizationServiceIntegrationTest.java
@@ -112,6 +112,24 @@ public class OrganizationServiceIntegrationTest extends IntegrationTestBase {
    }
 
    @Test
+   public void testUpdateOrganizationId() throws Exception {
+      String org = "UpdateOrganizationId";
+      String id = "UpdateOrganizationId_id";
+      organizationFacade.createOrganization(id, org);
+
+      String newId = "UpdateOrganizationId_newId";
+      final Client client = ClientBuilder.newBuilder().build();
+      client.target(TARGET_URI).path(PATH_PREFIX + id + "/id/" + newId)
+            .request(MediaType.APPLICATION_JSON)
+            .buildPut(Entity.entity(null, MediaType.APPLICATION_JSON))
+            .invoke();
+
+      String name = organizationFacade.readOrganizationName(newId);
+
+      assertThat(name).isEqualTo(org);
+   }
+
+   @Test
    public void testCreateOrganization() throws Exception {
       String org = "CreateOrganization";
       String id = "CreateOrganization_id";


### PR DESCRIPTION
As we discussed, I used _id from DataDocument rather than projectId/organizationId as unique and immutable identificator.