### PR TITLE
Remove _id attribute before patching data

### DIFF
--- a/lumeer-storage/lumeer-storage-mongodb/src/main/java/io/lumeer/storage/mongodb/dao/collection/MongoDataDao.java
+++ b/lumeer-storage/lumeer-storage-mongodb/src/main/java/io/lumeer/storage/mongodb/dao/collection/MongoDataDao.java
@@ -99,6 +99,7 @@ public class MongoDataDao extends CollectionScopedDao implements DataDao {
 
    @Override
    public DataDocument patchData(final String collectionId, final String documentId, final DataDocument data) {
+      data.remove(ID);
       Document updateDocument = new Document("$set", new Document(data));
       FindOneAndUpdateOptions options = new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER);
 


### PR DESCRIPTION
Without this fix, it is not possible to update the data record in the new table perspective.