### PR TITLE
Upgrade to MongoDB 3.6 #LMR-659

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -97,7 +97,7 @@
       <version.byteman>3.0.6</version.byteman>
       <version.servo>0.12.10</version.servo>
       <version.netty>4.1.6.Final</version.netty>
-      <version.mongo.driver>3.4.2</version.mongo.driver>
+      <version.mongo.driver>3.6.1</version.mongo.driver>
       <version.mongo.morphia>1.3.2</version.mongo.morphia>
       <version.keycloak>2.4.0.Final</version.keycloak>
       <version.jcommander>1.72</version.jcommander>
@@ -125,7 +125,7 @@
       <version.arquillian-jacoco>1.0.0.Alpha8</version.arquillian-jacoco>
       <version.mockito>2.8.47</version.mockito>
       <version.junit>4.12</version.junit>
-      <version.embedded.mongodb>2.0.0</version.embedded.mongodb>
+      <version.embedded.mongodb>2.0.1</version.embedded.mongodb>
 
       <java.level>1.8</java.level>
    </properties>

--- a/lumeer-storage/lumeer-storage-mongodb/src/test/java/io/lumeer/storage/mongodb/EmbeddedMongoDb.java
+++ b/lumeer-storage/lumeer-storage-mongodb/src/test/java/io/lumeer/storage/mongodb/EmbeddedMongoDb.java
@@ -56,7 +56,7 @@ public class EmbeddedMongoDb {
    private static IMongodConfig createMongoConfig() {
       try {
          return new MongodConfigBuilder()
-               .version(Version.Main.V3_4)
+               .version(Version.Main.V3_4) // TODO change to V3_6 once the library bug is fixed
                .net(new Net(HOST, PORT, Network.localhostIsIPv6()))
                .build();
       } catch (IOException ex) {


### PR DESCRIPTION
Tests are not yet run with this version due to a bug in the embedded MongoDB library.