### PR TITLE
Apply filters in search queries #LMR-368

### DIFF
--- a/api/src/main/java/io/lumeer/api/model/ConditionType.java
+++ b/api/src/main/java/io/lumeer/api/model/ConditionType.java
@@ -1,0 +1,57 @@
+/*
+ * Lumeer: Modern Data Definition and Processing Platform
+ *
+ * Copyright (C) since 2017 Answer Institute, s.r.o. and/or its affiliates.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.lumeer.api.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum ConditionType {
+
+   EQUALS,
+   NOT_EQUALS,
+   LOWER_THAN,
+   LOWER_THAN_EQUALS,
+   GREATER_THAN,
+   GREATER_THAN_EQUALS;
+
+   private static final List<String> EQ_VARIANTS = Arrays.asList("=", "==", "eq", "equals");
+   private static final List<String> NEQ_VARIANTS = Arrays.asList("!=", "!==", "<>", "ne", "neq", "nequals");
+   private static final List<String> LT_VARIANTS = Arrays.asList("<", "lt");
+   private static final List<String> LTE_VARIANTS = Arrays.asList("<=", "lte");
+   private static final List<String> GT_VARIANTS = Arrays.asList(">", "gt");
+   private static final List<String> GTE_VARIANTS = Arrays.asList(">=", "gte");
+
+   public static ConditionType fromString(String condition) {
+      if (EQ_VARIANTS.contains(condition)) {
+         return EQUALS;
+      } else if (NEQ_VARIANTS.contains(condition)) {
+         return NOT_EQUALS;
+      } else if (LT_VARIANTS.contains(condition)) {
+         return LOWER_THAN;
+      } else if (LTE_VARIANTS.contains(condition)) {
+         return LOWER_THAN_EQUALS;
+      } else if (GT_VARIANTS.contains(condition)) {
+         return GREATER_THAN;
+      } else if (GTE_VARIANTS.contains(condition)) {
+         return GREATER_THAN_EQUALS;
+      }
+      return null;
+   }
+
+}

--- a/lumeer-core/src/main/java/io/lumeer/core/util/FilterParser.java
+++ b/lumeer-core/src/main/java/io/lumeer/core/util/FilterParser.java
@@ -1,0 +1,51 @@
+/*
+ * Lumeer: Modern Data Definition and Processing Platform
+ *
+ * Copyright (C) since 2017 Answer Institute, s.r.o. and/or its affiliates.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.lumeer.core.util;
+
+import io.lumeer.api.model.ConditionType;
+import io.lumeer.storage.api.filter.AttributeFilter;
+
+public class FilterParser {
+
+   public static AttributeFilter parse(String filter) {
+      String[] parts = filter.split(":", 3);
+      if (parts.length < 3) {
+         return null;
+      }
+
+      String collectionId = parts[0].trim();
+      String attributeName = parts[1].trim();
+      String condition = parts[2].trim();
+
+      String[] conditionParts = condition.split(" +", 2); // one or more spaces
+      if (conditionParts.length < 2) {
+         return null;
+      }
+
+      ConditionType conditionType = ConditionType.fromString(conditionParts[0].trim().toLowerCase());
+      if (conditionType == null) {
+         return null;
+      }
+
+      String value = conditionParts[1].trim();
+
+      return new AttributeFilter(collectionId, conditionType, attributeName, value);
+   }
+
+}

--- a/lumeer-storage/lumeer-storage-api/src/main/java/io/lumeer/storage/api/filter/AttributeFilter.java
+++ b/lumeer-storage/lumeer-storage-api/src/main/java/io/lumeer/storage/api/filter/AttributeFilter.java
@@ -1,0 +1,85 @@
+/*
+ * Lumeer: Modern Data Definition and Processing Platform
+ *
+ * Copyright (C) since 2017 Answer Institute, s.r.o. and/or its affiliates.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.lumeer.storage.api.filter;
+
+import io.lumeer.api.model.ConditionType;
+
+import java.util.Objects;
+
+public class AttributeFilter {
+
+   private final String collectionId;
+   private final ConditionType conditionType;
+   private final String attributeName;
+   private final String value;
+
+   public AttributeFilter(final String collectionId, final ConditionType conditionType, final String attributeName, final String value) {
+      this.collectionId = collectionId;
+      this.conditionType = conditionType;
+      this.attributeName = attributeName;
+      this.value = value;
+   }
+
+   public String getCollectionId() {
+      return collectionId;
+   }
+
+   public ConditionType getConditionType() {
+      return conditionType;
+   }
+
+   public String getValue() {
+      return value;
+   }
+
+   public String getAttributeName() {
+      return attributeName;
+   }
+
+   @Override
+   public boolean equals(final Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (!(o instanceof AttributeFilter)) {
+         return false;
+      }
+      final AttributeFilter that = (AttributeFilter) o;
+      return Objects.equals(getCollectionId(), that.getCollectionId()) &&
+            getConditionType() == that.getConditionType() &&
+            Objects.equals(getValue(), that.getValue()) &&
+            Objects.equals(getAttributeName(), that.getAttributeName());
+   }
+
+   @Override
+   public int hashCode() {
+
+      return Objects.hash(getCollectionId(), getConditionType(), getValue(), getAttributeName());
+   }
+
+   @Override
+   public String toString() {
+      return "AttributeFilter{" +
+            "collectionId='" + collectionId + '\'' +
+            ", conditionType=" + conditionType +
+            ", value='" + value + '\'' +
+            ", attributeName='" + attributeName + '\'' +
+            '}';
+   }
+}

--- a/lumeer-storage/lumeer-storage-api/src/main/java/io/lumeer/storage/api/query/SearchQuery.java
+++ b/lumeer-storage/lumeer-storage-api/src/main/java/io/lumeer/storage/api/query/SearchQuery.java
@@ -18,6 +18,8 @@
  */
 package io.lumeer.storage.api.query;
 
+import io.lumeer.storage.api.filter.AttributeFilter;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -31,6 +33,7 @@ public class SearchQuery extends DatabaseQuery {
    private final Set<String> collectionIds;
    private final Set<String> linkTypeIds;
    private final Set<String> documentIds;
+   private final Set<AttributeFilter> filters;
 
    private SearchQuery(Builder builder) {
       super(builder);
@@ -40,6 +43,7 @@ public class SearchQuery extends DatabaseQuery {
       this.collectionIds = builder.collectionIds;
       this.linkTypeIds = builder.linkTypeIds;
       this.documentIds = builder.documentIds;
+      this.filters = builder.filters;
    }
 
    public String getFulltext() {
@@ -62,6 +66,10 @@ public class SearchQuery extends DatabaseQuery {
       return collectionIds != null ? Collections.unmodifiableSet(collectionIds) : Collections.emptySet();
    }
 
+   public Set<AttributeFilter> getFilters() {
+      return filters != null ? Collections.unmodifiableSet(filters) : Collections.emptySet();
+   }
+
    public boolean isFulltextQuery() {
       return fulltext != null && !fulltext.isEmpty();
    }
@@ -82,6 +90,10 @@ public class SearchQuery extends DatabaseQuery {
       return documentIds != null && !documentIds.isEmpty();
    }
 
+   public boolean isFiltersQuery() {
+      return filters != null && !filters.isEmpty();
+   }
+
    public boolean isBasicQuery() {
       return !isFulltextQuery() && !isCollectionCodesQuery() && !isLinkTypeIdsQuery() && !isDocumentIdsQuery() && !isCollectionIdsQuery();
    }
@@ -97,6 +109,7 @@ public class SearchQuery extends DatabaseQuery {
       private Set<String> collectionIds;
       private Set<String> linkTypeIds;
       private Set<String> documentIds;
+      private Set<AttributeFilter> filters;
 
       private Builder(final String user) {
          super(user);
@@ -124,6 +137,11 @@ public class SearchQuery extends DatabaseQuery {
 
       public Builder documentIds(Set<String> documentIds) {
          this.documentIds = documentIds;
+         return this;
+      }
+
+      public Builder filters(Set<AttributeFilter> attributeFilters) {
+         this.filters = attributeFilters;
          return this;
       }
 


### PR DESCRIPTION
For now filters on attributes only works for strings. Without storing types for attributes it's impossible to add support for other types.

Also there is support for multiple conditions like `equals`, `not equals`, `lower than`, `lower than and equals`, `greater than`, `greater than and equals` that work for strings as well.