### PR TITLE
Change document time representation #LMR-973

### DIFF
--- a/api/src/main/java/io/lumeer/api/dto/JsonDocument.java
+++ b/api/src/main/java/io/lumeer/api/dto/JsonDocument.java
@@ -18,6 +18,7 @@
  */
 package io.lumeer.api.dto;
 
+import io.lumeer.api.dto.adapter.ZonedDateTimeAdapter;
 import io.lumeer.api.model.Document;
 import io.lumeer.engine.api.data.DataDocument;
 
@@ -25,9 +26,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class JsonDocument implements Document {
@@ -36,8 +38,12 @@ public class JsonDocument implements Document {
 
    private String collectionId;
 
-   private LocalDateTime creationDate;
-   private LocalDateTime updateDate;
+   @XmlJavaTypeAdapter(ZonedDateTimeAdapter.class)
+   private ZonedDateTime creationDate;
+
+   @XmlJavaTypeAdapter(ZonedDateTimeAdapter.class)
+   private ZonedDateTime updateDate;
+
    private String createdBy;
    private String updatedBy;
    private Integer dataVersion;
@@ -82,22 +88,22 @@ public class JsonDocument implements Document {
    }
 
    @Override
-   public LocalDateTime getCreationDate() {
+   public ZonedDateTime getCreationDate() {
       return creationDate;
    }
 
    @Override
-   public void setCreationDate(final LocalDateTime creationDate) {
+   public void setCreationDate(final ZonedDateTime creationDate) {
       this.creationDate = creationDate;
    }
 
    @Override
-   public LocalDateTime getUpdateDate() {
+   public ZonedDateTime getUpdateDate() {
       return updateDate;
    }
 
    @Override
-   public void setUpdateDate(final LocalDateTime updateDate) {
+   public void setUpdateDate(final ZonedDateTime updateDate) {
       this.updateDate = updateDate;
    }
 

--- a/api/src/main/java/io/lumeer/api/dto/adapter/ZonedDateTimeAdapter.java
+++ b/api/src/main/java/io/lumeer/api/dto/adapter/ZonedDateTimeAdapter.java
@@ -16,44 +16,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.lumeer.api.model;
 
-import io.lumeer.engine.api.data.DataDocument;
+package io.lumeer.api.dto.adapter;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-public interface Document {
+public class ZonedDateTimeAdapter extends XmlAdapter<Long, ZonedDateTime> {
 
-   String getId();
+   public ZonedDateTime unmarshal(Long epochMillis) {
+      return epochMillis != null ? ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC) : null;
+   }
 
-   void setId(String id);
-
-   String getCollectionId();
-
-   void setCollectionId(String collectionId);
-
-   ZonedDateTime getCreationDate();
-
-   void setCreationDate(ZonedDateTime creationDate);
-
-   ZonedDateTime getUpdateDate();
-
-   void setUpdateDate(ZonedDateTime updateDate);
-
-   String getCreatedBy();
-
-   void setCreatedBy(String createdBy);
-
-   String getUpdatedBy();
-
-   void setUpdatedBy(String updatedBy);
-
-   Integer getDataVersion();
-
-   void setDataVersion(Integer dataVersion);
-
-   DataDocument getData();
-
-   void setData(DataDocument data);
+   public Long marshal(ZonedDateTime dateTime) {
+      return dateTime != null ? dateTime.toInstant().toEpochMilli() : null;
+   }
 
 }

--- a/lumeer-core/src/main/java/io/lumeer/core/facade/DocumentFacade.java
+++ b/lumeer-core/src/main/java/io/lumeer/core/facade/DocumentFacade.java
@@ -37,6 +37,7 @@ import io.lumeer.storage.api.exception.ResourceNotFoundException;
 import io.lumeer.storage.api.query.SearchQuery;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -90,7 +91,7 @@ public class DocumentFacade extends AbstractFacade {
    private Document createDocument(Collection collection, Document document) {
       document.setCollectionId(collection.getId());
       document.setCreatedBy(authenticatedUser.getCurrentUserId());
-      document.setCreationDate(LocalDateTime.now());
+      document.setCreationDate(ZonedDateTime.now());
       document.setDataVersion(INITIAL_VERSION);
       return documentDao.createDocument(document);
    }
@@ -142,7 +143,7 @@ public class DocumentFacade extends AbstractFacade {
 
       document.setCollectionId(collection.getId());
       document.setUpdatedBy(authenticatedUser.getCurrentUserId());
-      document.setUpdateDate(LocalDateTime.now());
+      document.setUpdateDate(ZonedDateTime.now());
       document.setDataVersion(document.getDataVersion() + 1);
 
       return documentDao.updateDocument(document.getId(), document);

--- a/lumeer-core/src/main/java/io/lumeer/core/facade/ImportFacade.java
+++ b/lumeer-core/src/main/java/io/lumeer/core/facade/ImportFacade.java
@@ -35,6 +35,7 @@ import com.univocity.parsers.csv.CsvParserSettings;
 
 import java.io.StringReader;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -184,7 +185,7 @@ public class ImportFacade extends AbstractFacade {
    private void addDocumentMetadata(String collectionId, Document document) {
       document.setCollectionId(collectionId);
       document.setCreatedBy(authenticatedUser.getCurrentUserId());
-      document.setCreationDate(LocalDateTime.now());
+      document.setCreationDate(ZonedDateTime.now());
       document.setDataVersion(DocumentFacade.INITIAL_VERSION);
    }
 

--- a/lumeer-storage/lumeer-storage-mongodb/src/main/java/io/lumeer/storage/mongodb/MongoDbStorage.java
+++ b/lumeer-storage/lumeer-storage-mongodb/src/main/java/io/lumeer/storage/mongodb/MongoDbStorage.java
@@ -36,6 +36,7 @@ import io.lumeer.engine.api.data.StorageConnection;
 import io.lumeer.engine.api.exception.UnsuccessfulOperationException;
 import io.lumeer.storage.mongodb.codecs.BigDecimalCodec;
 import io.lumeer.storage.mongodb.codecs.RoleCodec;
+import io.lumeer.storage.mongodb.codecs.ZonedDateTimeCodec;
 import io.lumeer.storage.mongodb.codecs.providers.AttributeCodecProvider;
 import io.lumeer.storage.mongodb.codecs.providers.CompanyContactCodedProvider;
 import io.lumeer.storage.mongodb.codecs.providers.GroupCodecProvider;
@@ -124,9 +125,12 @@ public class MongoDbStorage implements DataStorage {
          if (cache == null) {
             cache = cacheProvider.getCache(COLLECTION_CACHE);         // create and initialize actual instance
             if (collectionCacheRef.compareAndSet(null, cache)) // CAS succeeded
+            {
                return cache.get();
-            else                                                      // CAS failed: other thread set an object
+            } else                                                      // CAS failed: other thread set an object
+            {
                return collectionCacheRef.get().get();
+            }
          } else {
             return cache.get();
          }
@@ -161,7 +165,7 @@ public class MongoDbStorage implements DataStorage {
       }
 
       final CodecRegistry defaultRegistry = MongoClient.getDefaultCodecRegistry();
-      final CodecRegistry codecRegistry = CodecRegistries.fromCodecs(new BigDecimalCodec(), new RoleCodec());
+      final CodecRegistry codecRegistry = CodecRegistries.fromCodecs(new BigDecimalCodec(), new RoleCodec(), new ZonedDateTimeCodec());
       final CodecRegistry providersRegistry = CodecRegistries.fromProviders(
             new PermissionsCodecProvider(), new PermissionCodecProvider(), new QueryCodecProvider(), new ViewCodecProvider(),
             new AttributeCodecProvider(), new LinkInstanceCodecProvider(), new LinkTypeCodecProvider(), new UserCodecProvider(),

--- a/lumeer-storage/lumeer-storage-mongodb/src/main/java/io/lumeer/storage/mongodb/codecs/ZonedDateTimeCodec.java
+++ b/lumeer-storage/lumeer-storage-mongodb/src/main/java/io/lumeer/storage/mongodb/codecs/ZonedDateTimeCodec.java
@@ -1,0 +1,49 @@
+/*
+ * Lumeer: Modern Data Definition and Processing Platform
+ *
+ * Copyright (C) since 2017 Answer Institute, s.r.o. and/or its affiliates.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.lumeer.storage.mongodb.codecs;
+
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class ZonedDateTimeCodec implements Codec<ZonedDateTime> {
+
+   @Override
+   public ZonedDateTime decode(final BsonReader reader, final DecoderContext decoderContext) {
+      return ZonedDateTime.ofInstant(Instant.ofEpochMilli(reader.readDateTime()), ZoneOffset.UTC);
+   }
+
+   @Override
+   public void encode(final BsonWriter writer, final ZonedDateTime dateTime, final EncoderContext encoderContext) {
+      writer.writeDateTime(dateTime.toEpochSecond());
+   }
+
+   @Override
+   public Class<ZonedDateTime> getEncoderClass() {
+      return ZonedDateTime.class;
+   }
+
+}

--- a/lumeer-storage/lumeer-storage-mongodb/src/test/java/io/lumeer/storage/mongodb/dao/project/MorphiaDocumentDaoTest.java
+++ b/lumeer-storage/lumeer-storage-mongodb/src/test/java/io/lumeer/storage/mongodb/dao/project/MorphiaDocumentDaoTest.java
@@ -38,7 +38,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public class MorphiaDocumentDaoTest extends MongoDbTestBase {
@@ -53,7 +53,7 @@ public class MorphiaDocumentDaoTest extends MongoDbTestBase {
    private static final String USER2 = "testUser2";
 
    private static final String COLLECTION_ID = "59a51b83d412bc2da88b010f";
-   private static final LocalDateTime CREATION_DATE = LocalDateTime.now().withNano(0);
+   private static final ZonedDateTime CREATION_DATE = ZonedDateTime.now().withNano(0);
    private static final String CREATED_BY = USER;
    private static final int DATA_VERSION = 1;
 
@@ -140,7 +140,7 @@ public class MorphiaDocumentDaoTest extends MongoDbTestBase {
       MorphiaDocument document = createDocument();
       String id = document.getId();
 
-      LocalDateTime updateDate = LocalDateTime.now().withNano(0);
+      ZonedDateTime updateDate = ZonedDateTime.now().withNano(0);
       document.setDataVersion(DATA_VERSION2);
       document.setUpdatedBy(UPDATED_BY);
       document.setUpdateDate(updateDate);

--- a/war/src/test/java/io/lumeer/core/facade/DocumentFacadeIT.java
+++ b/war/src/test/java/io/lumeer/core/facade/DocumentFacadeIT.java
@@ -55,7 +55,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -165,7 +165,7 @@ public class DocumentFacadeIT extends IntegrationTestBase {
 
       Document document = prepareDocument();
 
-      LocalDateTime beforeTime = LocalDateTime.now();
+      ZonedDateTime beforeTime = ZonedDateTime.now();
       String id = documentFacade.createDocument(collection.getId(), document).getId();
       assertThat(id).isNotNull();
 
@@ -176,7 +176,7 @@ public class DocumentFacadeIT extends IntegrationTestBase {
       assertions.assertThat(storedDocument.getId()).isEqualTo(id);
       assertions.assertThat(storedDocument.getCollectionId()).isEqualTo(collection.getId());
       assertions.assertThat(storedDocument.getCreatedBy()).isEqualTo(this.user.getId());
-      assertions.assertThat(storedDocument.getCreationDate()).isAfterOrEqualTo(beforeTime).isBeforeOrEqualTo(LocalDateTime.now());
+      assertions.assertThat(storedDocument.getCreationDate()).isAfterOrEqualTo(beforeTime).isBeforeOrEqualTo(ZonedDateTime.now());
       assertions.assertThat(storedDocument.getUpdatedBy()).isNull();
       assertions.assertThat(storedDocument.getUpdateDate()).isNull();
       assertions.assertThat(storedDocument.getDataVersion()).isEqualTo(1);
@@ -204,7 +204,7 @@ public class DocumentFacadeIT extends IntegrationTestBase {
 
       DataDocument data = new DataDocument(KEY1, VALUE2);
 
-      LocalDateTime beforeUpdateTime = LocalDateTime.now();
+      ZonedDateTime beforeUpdateTime = ZonedDateTime.now();
       Document updatedDocument = documentFacade.updateDocumentData(collection.getId(), id, data);
       assertThat(updatedDocument).isNotNull();
 
@@ -215,7 +215,7 @@ public class DocumentFacadeIT extends IntegrationTestBase {
       assertions.assertThat(storedDocument.getCreatedBy()).isEqualTo(this.user.getId());
       assertions.assertThat(storedDocument.getCreationDate()).isBeforeOrEqualTo(beforeUpdateTime);
       assertions.assertThat(storedDocument.getUpdatedBy()).isEqualTo(this.user.getId());
-      assertions.assertThat(storedDocument.getUpdateDate()).isAfterOrEqualTo(beforeUpdateTime).isBeforeOrEqualTo(LocalDateTime.now());
+      assertions.assertThat(storedDocument.getUpdateDate()).isAfterOrEqualTo(beforeUpdateTime).isBeforeOrEqualTo(ZonedDateTime.now());
       assertions.assertThat(storedDocument.getDataVersion()).isEqualTo(2);
       assertions.assertThat(storedDocument.getData()).isNull();
       assertions.assertAll();
@@ -241,7 +241,7 @@ public class DocumentFacadeIT extends IntegrationTestBase {
 
       DataDocument data = new DataDocument(KEY1, VALUE2);
 
-      LocalDateTime beforeUpdateTime = LocalDateTime.now();
+      ZonedDateTime beforeUpdateTime = ZonedDateTime.now();
       Document updatedDocument = documentFacade.patchDocumentData(collection.getId(), id, data);
       assertThat(updatedDocument).isNotNull();
 
@@ -252,7 +252,7 @@ public class DocumentFacadeIT extends IntegrationTestBase {
       assertions.assertThat(storedDocument.getCreatedBy()).isEqualTo(this.user.getId());
       assertions.assertThat(storedDocument.getCreationDate()).isBeforeOrEqualTo(beforeUpdateTime);
       assertions.assertThat(storedDocument.getUpdatedBy()).isEqualTo(this.user.getId());
-      assertions.assertThat(storedDocument.getUpdateDate()).isAfterOrEqualTo(beforeUpdateTime).isBeforeOrEqualTo(LocalDateTime.now());
+      assertions.assertThat(storedDocument.getUpdateDate()).isAfterOrEqualTo(beforeUpdateTime).isBeforeOrEqualTo(ZonedDateTime.now());
       assertions.assertThat(storedDocument.getDataVersion()).isEqualTo(2);
       assertions.assertThat(storedDocument.getData()).isNull();
       assertions.assertAll();
@@ -298,7 +298,7 @@ public class DocumentFacadeIT extends IntegrationTestBase {
       assertions.assertThat(document.getId()).isEqualTo(id);
       assertions.assertThat(document.getCollectionId()).isEqualTo(collection.getId());
       assertions.assertThat(document.getCreatedBy()).isEqualTo(this.user.getId());
-      assertions.assertThat(document.getCreationDate()).isBeforeOrEqualTo(LocalDateTime.now());
+      assertions.assertThat(document.getCreationDate()).isBeforeOrEqualTo(ZonedDateTime.now());
       assertions.assertThat(document.getUpdatedBy()).isNull();
       assertions.assertThat(document.getUpdateDate()).isNull();
       assertions.assertThat(document.getDataVersion()).isEqualTo(1);

--- a/war/src/test/java/io/lumeer/core/facade/LinkInstanceFacadeIT.java
+++ b/war/src/test/java/io/lumeer/core/facade/LinkInstanceFacadeIT.java
@@ -59,7 +59,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -292,7 +292,7 @@ public class LinkInstanceFacadeIT extends IntegrationTestBase {
       Document document = prepareDocument();
       document.setCollectionId(collectionId);
       document.setCreatedBy(USER);
-      document.setCreationDate(LocalDateTime.now());
+      document.setCreationDate(ZonedDateTime.now());
       document.setDataVersion(DocumentFacade.INITIAL_VERSION);
       Document storedDocument = documentDao.createDocument(document);
 

--- a/war/src/test/java/io/lumeer/core/facade/SearchFacadeIT.java
+++ b/war/src/test/java/io/lumeer/core/facade/SearchFacadeIT.java
@@ -49,7 +49,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -302,7 +302,7 @@ public class SearchFacadeIT extends IntegrationTestBase {
       Document document = new JsonDocument(new DataDocument(DOCUMENT_KEY, value));
       document.setCollectionId(collectionId);
       document.setCreatedBy(USER);
-      document.setCreationDate(LocalDateTime.now());
+      document.setCreationDate(ZonedDateTime.now());
       document.setDataVersion(DocumentFacade.INITIAL_VERSION);
       Document storedDocument = documentDao.createDocument(document);
 

--- a/war/src/test/java/io/lumeer/remote/rest/DocumentServiceIT.java
+++ b/war/src/test/java/io/lumeer/remote/rest/DocumentServiceIT.java
@@ -55,6 +55,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -156,7 +157,7 @@ public class DocumentServiceIT extends ServiceIntegrationTestBase {
       Document document = prepareDocument();
       document.setCollectionId(collection.getId());
       document.setCreatedBy(this.user.getId());
-      document.setCreationDate(LocalDateTime.now());
+      document.setCreationDate(ZonedDateTime.now());
       document.setDataVersion(DocumentFacade.INITIAL_VERSION);
       Document storedDocument = documentDao.createDocument(document);
 
@@ -171,7 +172,7 @@ public class DocumentServiceIT extends ServiceIntegrationTestBase {
       Document document = prepareDocument();
       Entity entity = Entity.json(document);
 
-      LocalDateTime beforeTime = LocalDateTime.now();
+      ZonedDateTime beforeTime = ZonedDateTime.now();
 
       Response response = client.target(DOCUMENTS_URL_PREFIX).path(collection.getId()).path("documents")
                                 .request(MediaType.APPLICATION_JSON)
@@ -191,7 +192,7 @@ public class DocumentServiceIT extends ServiceIntegrationTestBase {
       assertions.assertThat(storedDocument.getId()).isEqualTo(id);
       assertions.assertThat(storedDocument.getCollectionId()).isEqualTo(collection.getId());
       assertions.assertThat(storedDocument.getCreatedBy()).isEqualTo(this.user.getId());
-      assertions.assertThat(storedDocument.getCreationDate()).isAfterOrEqualTo(beforeTime).isBeforeOrEqualTo(LocalDateTime.now());
+      assertions.assertThat(storedDocument.getCreationDate()).isAfterOrEqualTo(beforeTime).isBeforeOrEqualTo(ZonedDateTime.now());
       assertions.assertThat(storedDocument.getUpdatedBy()).isNull();
       assertions.assertThat(storedDocument.getUpdateDate()).isNull();
       assertions.assertThat(storedDocument.getDataVersion()).isEqualTo(1);
@@ -211,7 +212,7 @@ public class DocumentServiceIT extends ServiceIntegrationTestBase {
       DataDocument data = new DataDocument(KEY1, VALUE2);
       Entity entity = Entity.json(data);
 
-      LocalDateTime beforeUpdateTime = LocalDateTime.now();
+      ZonedDateTime beforeUpdateTime = ZonedDateTime.now();
       Response response = client.target(DOCUMENTS_URL_PREFIX).path(collection.getId()).path("documents").path(id).path("data")
                                 .request(MediaType.APPLICATION_JSON)
                                 .buildPut(entity).invoke();
@@ -225,7 +226,7 @@ public class DocumentServiceIT extends ServiceIntegrationTestBase {
       assertions.assertThat(storedDocument.getCreatedBy()).isEqualTo(this.user.getId());
       assertions.assertThat(storedDocument.getCreationDate()).isBeforeOrEqualTo(beforeUpdateTime);
       assertions.assertThat(storedDocument.getUpdatedBy()).isEqualTo(this.user.getId());
-      assertions.assertThat(storedDocument.getUpdateDate()).isAfterOrEqualTo(beforeUpdateTime).isBeforeOrEqualTo(LocalDateTime.now());
+      assertions.assertThat(storedDocument.getUpdateDate()).isAfterOrEqualTo(beforeUpdateTime).isBeforeOrEqualTo(ZonedDateTime.now());
       assertions.assertThat(storedDocument.getDataVersion()).isEqualTo(2);
       assertions.assertThat(storedDocument.getData()).isNull();
       assertions.assertAll();
@@ -243,7 +244,7 @@ public class DocumentServiceIT extends ServiceIntegrationTestBase {
       DataDocument data = new DataDocument(KEY1, VALUE2);
       Entity entity = Entity.json(data);
 
-      LocalDateTime beforeUpdateTime = LocalDateTime.now();
+      ZonedDateTime beforeUpdateTime = ZonedDateTime.now();
       Response response = client.target(DOCUMENTS_URL_PREFIX).path(collection.getId()).path("documents").path(id).path("data")
                                 .request(MediaType.APPLICATION_JSON)
                                 .build("PATCH", entity).invoke();
@@ -257,7 +258,7 @@ public class DocumentServiceIT extends ServiceIntegrationTestBase {
       assertions.assertThat(storedDocument.getCreatedBy()).isEqualTo(this.user.getId());
       assertions.assertThat(storedDocument.getCreationDate()).isBeforeOrEqualTo(beforeUpdateTime);
       assertions.assertThat(storedDocument.getUpdatedBy()).isEqualTo(this.user.getId());
-      assertions.assertThat(storedDocument.getUpdateDate()).isAfterOrEqualTo(beforeUpdateTime).isBeforeOrEqualTo(LocalDateTime.now());
+      assertions.assertThat(storedDocument.getUpdateDate()).isAfterOrEqualTo(beforeUpdateTime).isBeforeOrEqualTo(ZonedDateTime.now());
       assertions.assertThat(storedDocument.getDataVersion()).isEqualTo(2);
       assertions.assertThat(storedDocument.getData()).isNull();
       assertions.assertAll();
@@ -301,7 +302,7 @@ public class DocumentServiceIT extends ServiceIntegrationTestBase {
       assertions.assertThat(document.getId()).isEqualTo(id);
       assertions.assertThat(document.getCollectionId()).isNull();
       assertions.assertThat(document.getCreatedBy()).isEqualTo(this.user.getId());
-      assertions.assertThat(document.getCreationDate()).isBeforeOrEqualTo(LocalDateTime.now());
+      assertions.assertThat(document.getCreationDate()).isBeforeOrEqualTo(ZonedDateTime.now());
       assertions.assertThat(document.getUpdatedBy()).isNull();
       assertions.assertThat(document.getUpdateDate()).isNull();
       assertions.assertThat(document.getDataVersion()).isEqualTo(1);

--- a/war/src/test/java/io/lumeer/remote/rest/LinkInstanceServiceIT.java
+++ b/war/src/test/java/io/lumeer/remote/rest/LinkInstanceServiceIT.java
@@ -56,7 +56,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -369,7 +369,7 @@ public class LinkInstanceServiceIT extends ServiceIntegrationTestBase {
       Document document = prepareDocument();
       document.setCollectionId(collectionId);
       document.setCreatedBy(USER);
-      document.setCreationDate(LocalDateTime.now());
+      document.setCreationDate(ZonedDateTime.now());
       document.setDataVersion(DocumentFacade.INITIAL_VERSION);
       Document storedDocument = documentDao.createDocument(document);
 


### PR DESCRIPTION
This PR changes the representation of date and time in documents metadata this way:
* store time in database as MongoDB ISODate in UTC
* work with time in application as java.time.ZonedDateTime
* provide time through REST API as milliseconds since Unix epoch

It should fix problems with date and time in different time zones. Something similar would need to be done with collections as well.

**Do not merge this before the PR with table UX fixes is merged! Otherwise it would break the application.**